### PR TITLE
Adding zlib-musl from core-plans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.zlib-musl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=190&branchName=master)
+
 # zlib-musl
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# zlib-musl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "zlib-musl"

--- a/controls/zlib_musl_test.rb
+++ b/controls/zlib_musl_test.rb
@@ -1,0 +1,27 @@
+title 'Tests to confirm zlib-musl works as expected'
+
+plan_name = input('plan_name', value: 'zlib-musl')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-zlib-musl' do
+  impact 1.0
+  title 'Ensure zlib-musl works'
+  desc '
+  We confirm that the zlib-musl library is present in the expected location.
+
+    $ ls -al <pkg>/lib/libz.so
+  '
+  zlib_musl_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe zlib_musl_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  zlib_musl_pkg_ident = zlib_musl_pkg_ident.stdout.strip
+
+  describe command("ls -al #{zlib_musl_pkg_ident}/lib/libz.so") do
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{zlib_musl_pkg_ident}/}
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: zlib-musl
+title: Habitat Core Plan for zlib-musl
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan for zlib-musl
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,43 @@
+pkg_name=zlib-musl
+_distname="zlib"
+pkg_origin=core
+pkg_version=1.2.11
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Compression library implementing the deflate compression method found in gzip \
+and PKZIP.\
+"
+pkg_upstream_url="http://www.zlib.net/"
+pkg_license=('zlib')
+pkg_source="http://zlib.net/${_distname}-${pkg_version}.tar.gz"
+pkg_shasum="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_license=('zlib')
+pkg_deps=(
+  core/musl
+)
+pkg_build_deps=(
+  core/patch
+  core/make
+  core/gcc
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_prepare() {
+  export CC=musl-gcc
+  build_line "Setting CC=$CC"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=()
+fi


### PR DESCRIPTION
Migration from core plans, minus previous sourcing pattern.

```
Profile: Habitat Core Plan for zlib-musl (zlib-musl)
Version: 0.1.0
Target:  docker://01333341a016658bab7e5f58e8e27717d2c6d5cfc00fc845cc01228648826f42

  ✔  core-plans-zlib-musl: Ensure zlib-musl works
     ✔  Command: `hab pkg path habskp/zlib-musl` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/zlib-musl` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/zlib-musl/1.2.11/20200610082333/lib/libz.so` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/zlib-musl/1.2.11/20200610082333/lib/libz.so` stdout is expected to match /\/hab\/pkgs\/habskp\/zlib-musl\/1.2.11\/20200610082333/
     ✔  Command: `ls -al /hab/pkgs/habskp/zlib-musl/1.2.11/20200610082333/lib/libz.so` exit_status is expected to eq 0
```


﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
